### PR TITLE
Add bin (hard and soft) descriptions to node properties

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source 'http://rubygems.org'
 
 # Specify your gem's dependencies in atp.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       sexpistol (~> 0.0)
 
 GEM
-  remote: https://rubygems.org/
+  remote: http://rubygems.org/
   specs:
     activesupport (4.2.7.1)
       i18n (~> 0.7)

--- a/lib/atp/ast/builder.rb
+++ b/lib/atp/ast/builder.rb
@@ -263,12 +263,12 @@ module ATP
         children = []
         children << type
         if options[:bin] && options[:bin_description]
-          children << n(:bin, options[:bin], bin_description: options[:bin_description])
+          children << n(:bin, options[:bin], options[:bin_description])
         else
           children << n(:bin, options[:bin]) if options[:bin]
         end
         if options[:softbin] && options[:softbin_description]
-          children << n(:softbin, options[:softbin], softbin_description: options[:softbin_description])
+          children << n(:softbin, options[:softbin], options[:softbin_description])
         else
           children << n(:softbin, options[:softbin]) if options[:softbin]
         end

--- a/lib/atp/ast/builder.rb
+++ b/lib/atp/ast/builder.rb
@@ -230,35 +230,46 @@ module ATP
       def on_fail(options = {})
         children = []
         if options[:bin] || options[:softbin]
-          children << set_result(:fail, bin: options[:bin], softbin: options[:softbin], bin_description: options[:bin_description])
+          fail_opts = { bin: options[:bin], softbin: options[:softbin] }
+          fail_opts[:bin_description] = options[:bin_description] if options[:bin_description]
+          fail_opts[:softbin_description] = options[:softbin_description] if options[:softbin_description]
+          children << set_result(:fail, fail_opts)
         end
         if options[:set_run_flag] || options[:set_flag]
           children << set_run_flag(options[:set_run_flag] || options[:set_flag])
         end
         children << continue if options[:continue]
-        children << render(options[:render]) if options[:render]
         n(:on_fail, *children)
       end
 
       def on_pass(options = {})
         children = []
         if options[:bin] || options[:softbin]
-          children << set_result(:pass, bin: options[:bin], softbin: options[:softbin], bin_description: options[:bin_description])
+          pass_opts = { bin: options[:bin], softbin: options[:softbin] }
+          pass_opts[:bin_description] = options[:bin_description] if options[:bin_description]
+          pass_opts[:softbin_description] = options[:softbin_description] if options[:softbin_description]
+          children << set_result(:pass, pass_opts)
         end
         if options[:set_run_flag] || options[:set_flag]
           children << set_run_flag(options[:set_run_flag] || options[:set_flag])
         end
         children << continue if options[:continue]
-        children << render(options[:render]) if options[:render]
         n(:on_pass, *children)
       end
 
       def set_result(type, options = {})
         children = []
         children << type
-        children << n(:bin, options[:bin])  if options[:bin]
-        children << n(:softbin, options[:softbin])  if options[:softbin]
-        children << n(:bin_description, options[:bin_description])  if options[:bin_description]
+        if options[:bin] && options[:bin_description]
+          children << n(:bin, options[:bin], bin_description: options[:bin_description])
+        else
+          children << n(:bin, options[:bin]) if options[:bin]
+        end
+        if options[:softbin] && options[:softbin_description]
+          children << n(:softbin, options[:softbin], softbin_description: options[:softbin_description])
+        else
+          children << n(:softbin, options[:softbin]) if options[:softbin]
+        end
         result = n(:set_result, *children)
 
         if options[:conditions]

--- a/lib/atp/ast/builder.rb
+++ b/lib/atp/ast/builder.rb
@@ -239,6 +239,7 @@ module ATP
           children << set_run_flag(options[:set_run_flag] || options[:set_flag])
         end
         children << continue if options[:continue]
+        children << render(options[:render]) if options[:render]
         n(:on_fail, *children)
       end
 
@@ -254,6 +255,7 @@ module ATP
           children << set_run_flag(options[:set_run_flag] || options[:set_flag])
         end
         children << continue if options[:continue]
+        children << render(options[:render]) if options[:render]
         n(:on_pass, *children)
       end
 

--- a/lib/atp/ast/node.rb
+++ b/lib/atp/ast/node.rb
@@ -4,8 +4,8 @@ module ATP
     class Node < ::AST::Node
       include Factories
 
-      attr_reader :file, :line_number, :description, :bin_description, :softbin_description
-
+      attr_reader :file, :line_number, :description
+      
       def initialize(type, children = [], properties = {})
         # Always use strings instead of symbols in the AST, makes serializing
         # back and forward to a string easier
@@ -58,6 +58,26 @@ module ATP
         val
       end
 
+      # Returns the description found at the second location of an AST node like this:
+      #
+      #   node # => (SCALAR-ID "Instrument", "Description")
+      #
+      #   node.value  # => "Description"
+      #
+      # Simple error checking to verify that only bin and softbin type nodes can use
+      # this node successfully, but ultimately, the caller is responsible for calling 
+      # this only on compatible nodes.
+       def desc
+        if type == :bin || type == :softbin
+          if children.size > 1
+            unless children[1].respond_to?(:children)
+              desc = children[1]
+            end
+          end
+        end
+        desc
+      end
+      
       # Add the given nodes to the children
       def add(*nodes)
         updated(nil, children + nodes)

--- a/lib/atp/ast/node.rb
+++ b/lib/atp/ast/node.rb
@@ -4,7 +4,7 @@ module ATP
     class Node < ::AST::Node
       include Factories
 
-      attr_reader :file, :line_number, :description
+      attr_reader :file, :line_number, :description, :bin_description, :softbin_description
 
       def initialize(type, children = [], properties = {})
         # Always use strings instead of symbols in the AST, makes serializing

--- a/lib/atp/ast/node.rb
+++ b/lib/atp/ast/node.rb
@@ -57,26 +57,6 @@ module ATP
         val = val.children.first while val.respond_to?(:children)
         val
       end
-
-      # Returns the description found at the second location of an AST node like this:
-      #
-      #   node # => (SCALAR-ID "Instrument", "Description")
-      #
-      #   node.value  # => "Description"
-      #
-      # Simple error checking to verify that only bin and softbin type nodes can use
-      # this node successfully, but ultimately, the caller is responsible for calling 
-      # this only on compatible nodes.
-       def desc
-        if type == :bin || type == :softbin
-          if children.size > 1
-            unless children[1].respond_to?(:children)
-              desc = children[1]
-            end
-          end
-        end
-        desc
-      end
       
       # Add the given nodes to the children
       def add(*nodes)

--- a/lib/atp/flow.rb
+++ b/lib/atp/flow.rb
@@ -82,6 +82,10 @@ module ATP
           options[:on_fail] ||= {}
           options[:on_fail][:softbin] = b
         end
+        if b = options.delete(:softbin_description) || options.delete(:sbin_description) || options.delete(:soft_bin_description)
+          options[:on_fail] ||= {}
+          options[:on_fail][:softbin_description] = b
+        end
         if options.delete(:continue)
           options[:on_fail] ||= {}
           options[:on_fail][:continue] = true

--- a/lib/atp/flow.rb
+++ b/lib/atp/flow.rb
@@ -74,6 +74,10 @@ module ATP
           options[:on_fail] ||= {}
           options[:on_fail][:bin] = b
         end
+        if b = options.delete(:bin_description)
+          options[:on_fail] ||= {}
+          options[:on_fail][:bin_description] = b
+        end
         if b = options.delete(:softbin) || b = options.delete(:sbin) || b = options.delete(:soft_bin)
           options[:on_fail] ||= {}
           options[:on_fail][:softbin] = b

--- a/spec/flow_spec.rb
+++ b/spec/flow_spec.rb
@@ -153,24 +153,65 @@ describe 'The flow builder API' do
     it "flow.test with bin descriptions" do
       f = new_flow
       f.test("test1", bin: 1, softbin: 10, continue: true)
-      f.test("test2", bin: 1, bin_description: 'hbin2 fails', softbin: 10, continue: true)
-      f.test("test3", bin: 1, softbin: 10, softbin_description: 'sbin3 fails', continue: true)
-      f.test("test4", bin: 1, bin_description: 'hbin4 fails', softbin: 10, softbin_description: 'sbin4 fails', continue: true)
+      f.test("test2", bin: 2, bin_description: 'hbin2 fails', softbin: 20, continue: true)
+      f.test("test3", bin: 3, softbin: 30, softbin_description: 'sbin3 fails', continue: true)
+      f.test("test4", bin: 4, bin_description: 'hbin4 fails', softbin: 40, softbin_description: 'sbin4 fails', continue: true)
+   
+      f.ast.should ==
+        s(:flow,
+          s(:name, "sort1"),
+          s(:test,
+            s(:object, "test1"),
+            s(:on_fail,
+              s(:set_result, "fail",
+                s(:bin, 1),
+                s(:softbin, 10)),
+              s(:continue))),
+          s(:test,
+            s(:object, "test2"),
+            s(:on_fail,
+              s(:set_result, "fail",
+                s(:bin, 2, "hbin2 fails"),
+                s(:softbin, 20)),
+              s(:continue))),
+          s(:test,
+            s(:object, "test3"),
+            s(:on_fail,
+              s(:set_result, "fail",
+                s(:bin, 3),
+                s(:softbin, 30, "sbin3 fails")),
+              s(:continue))),
+          s(:test,
+            s(:object, "test4"),
+            s(:on_fail,
+              s(:set_result, "fail",
+                s(:bin, 4, "hbin4 fails"),
+                s(:softbin, 40, "sbin4 fails")),
+              s(:continue))))
+      
       f.ast.find_all(:test).each do |test_node|
         set_result_node = test_node.find(:on_fail).find(:set_result)
         case test_node.find(:object).try(:value)
           when 'test1'
-            set_result_node.find(:bin).try(:bin_description).should == nil
-            set_result_node.find(:softbin).try(:softbin_description).should == nil
+            set_result_node.find(:bin).try(:value).should == 1
+            set_result_node.find(:softbin).try(:desc).should == nil
+            set_result_node.find(:softbin).try(:value).should == 10
+            set_result_node.find(:softbin).try(:desc).should == nil
           when 'test2'
-            set_result_node.find(:bin).try(:bin_description).should == 'hbin2 fails'
-            set_result_node.find(:softbin).try(:softbin_description).should == nil
+            set_result_node.find(:bin).try(:value).should == 2
+            set_result_node.find(:bin).try(:desc).should == 'hbin2 fails'
+            set_result_node.find(:softbin).try(:value).should == 20
+            set_result_node.find(:softbin).try(:desc).should == nil
           when 'test3'
-            set_result_node.find(:bin).try(:bin_description).should == nil
-            set_result_node.find(:softbin).try(:softbin_description).should == 'sbin3 fails'
+            set_result_node.find(:bin).try(:value).should == 3
+            set_result_node.find(:bin).try(:desc).should == nil
+            set_result_node.find(:softbin).try(:value).should == 30
+            set_result_node.find(:softbin).try(:desc).should == 'sbin3 fails'
           when 'test4'
-            set_result_node.find(:bin).try(:bin_description).should == 'hbin4 fails'
-            set_result_node.find(:softbin).try(:softbin_description).should == 'sbin4 fails'
+            set_result_node.find(:bin).try(:value).should == 4
+            set_result_node.find(:bin).try(:desc).should == 'hbin4 fails'
+            set_result_node.find(:softbin).try(:value).should == 40
+            set_result_node.find(:softbin).try(:desc).should == 'sbin4 fails'
         end
       end
     end

--- a/spec/flow_spec.rb
+++ b/spec/flow_spec.rb
@@ -194,24 +194,24 @@ describe 'The flow builder API' do
         case test_node.find(:object).try(:value)
           when 'test1'
             set_result_node.find(:bin).try(:value).should == 1
-            set_result_node.find(:softbin).try(:desc).should == nil
+            set_result_node.find(:bin).to_a[1].should == nil
             set_result_node.find(:softbin).try(:value).should == 10
-            set_result_node.find(:softbin).try(:desc).should == nil
+            set_result_node.find(:softbin).to_a[1].should == nil
           when 'test2'
             set_result_node.find(:bin).try(:value).should == 2
-            set_result_node.find(:bin).try(:desc).should == 'hbin2 fails'
+            set_result_node.find(:bin).to_a[1].should == 'hbin2 fails'
             set_result_node.find(:softbin).try(:value).should == 20
-            set_result_node.find(:softbin).try(:desc).should == nil
+            set_result_node.find(:softbin).to_a[1].should == nil
           when 'test3'
             set_result_node.find(:bin).try(:value).should == 3
-            set_result_node.find(:bin).try(:desc).should == nil
+            set_result_node.find(:bin).to_a[1].should == nil
             set_result_node.find(:softbin).try(:value).should == 30
-            set_result_node.find(:softbin).try(:desc).should == 'sbin3 fails'
+            set_result_node.find(:softbin).to_a[1].should == 'sbin3 fails'
           when 'test4'
             set_result_node.find(:bin).try(:value).should == 4
-            set_result_node.find(:bin).try(:desc).should == 'hbin4 fails'
+            set_result_node.find(:bin).to_a[1].should == 'hbin4 fails'
             set_result_node.find(:softbin).try(:value).should == 40
-            set_result_node.find(:softbin).try(:desc).should == 'sbin4 fails'
+            set_result_node.find(:softbin).to_a[1].should == 'sbin4 fails'
         end
       end
     end


### PR DESCRIPTION
Track bin description as a property of a node so that it can be used during program rendering if desired.