### PR TITLE
Add identifying child to auto-generated set-flag nodes

### DIFF
--- a/lib/atp/processor.rb
+++ b/lib/atp/processor.rb
@@ -42,5 +42,5 @@ module ATP
     def n2(type, arg1, arg2)
       n(type, [arg1, arg2])
     end
-   end
+  end
 end

--- a/lib/atp/processor.rb
+++ b/lib/atp/processor.rb
@@ -38,5 +38,9 @@ module ATP
     def n1(type, arg)
       n(type, [arg])
     end
-  end
+
+    def n2(type, arg1, arg2)
+      n(type, [arg1, arg2])
+    end
+   end
 end

--- a/lib/atp/processors/relationship.rb
+++ b/lib/atp/processors/relationship.rb
@@ -61,7 +61,7 @@ module ATP
         node = node.ensure_node_present(:on_fail)
         node.updated(nil, node.children.map do |n|
           if n.type == :on_pass
-            n = n.add n1(:set_run_flag, "#{id}_PASSED")
+            n = n.add n2(:set_run_flag, "#{id}_PASSED", :auto_generated)
           elsif n.type == :on_fail
             n.ensure_node_present(:continue)
           else
@@ -74,7 +74,7 @@ module ATP
         node = node.ensure_node_present(:on_fail)
         node.updated(nil, node.children.map do |n|
           if n.type == :on_fail
-            n = n.add n1(:set_run_flag, "#{id}_FAILED")
+            n = n.add n2(:set_run_flag, "#{id}_FAILED", :auto_generated)
             n.ensure_node_present(:continue)
           else
             n
@@ -87,7 +87,7 @@ module ATP
         node = node.ensure_node_present(:on_pass)
         node.updated(nil, node.children.map do |n|
           if n.type == :on_pass || n.type == :on_fail
-            n = n.add n1(:set_run_flag, "#{id}_RAN")
+            n = n.add n2(:set_run_flag, "#{id}_RAN", :auto_generated)
           else
             n
           end

--- a/spec/flow_spec.rb
+++ b/spec/flow_spec.rb
@@ -112,7 +112,7 @@ describe 'The flow builder API' do
           s(:test,
             s(:object, "test3")),
           s(:on_fail,
-            s(:set_run_flag, "g1_FAILED"),
+            s(:set_run_flag, "g1_FAILED", "auto_generated"),
             s(:continue))),
         s(:run_flag, "g1_FAILED", true,
           s(:group, 

--- a/spec/optimization_spec.rb
+++ b/spec/optimization_spec.rb
@@ -81,7 +81,7 @@ describe 'AST optimization' do
             (on-fail
               (bin 90)))
           (on-fail
-            (set-run-flag "gt_grp1_FAILED")
+            (set-run-flag "gt_grp1_FAILED" "auto_generated")
             (continue)))
         (run-flag "gt_grp1_FAILED" true
           (test
@@ -100,7 +100,7 @@ describe 'AST optimization' do
               (on-fail
                 (bin 90)))
             (on-fail
-              (set-run-flag "gt_grp2_FAILED")
+              (set-run-flag "gt_grp2_FAILED" "auto_generated")
               (continue))))
         (run-flag "gt_grp2_FAILED" true
           (test
@@ -188,7 +188,7 @@ describe 'AST optimization' do
             (id "l1t3")
             (on-fail
               (bin 10)
-              (set-run-flag "l1t3_FAILED")
+              (set-run-flag "l1t3_FAILED" "auto_generated")
               (continue)))
           (run-flag "l1t3_FAILED" true
             (test
@@ -200,7 +200,7 @@ describe 'AST optimization' do
             (id "l1t5")
             (on-fail
               (bin 12)
-              (set-run-flag "l1t5_FAILED")
+              (set-run-flag "l1t5_FAILED" "auto_generated")
               (continue)))
           (group
             (name "level2")
@@ -217,7 +217,7 @@ describe 'AST optimization' do
               (id "l2t3")
               (on-fail
                 (bin 10)
-                (set-run-flag "l2t3_FAILED")
+                (set-run-flag "l2t3_FAILED" "auto_generated")
                 (continue)))
             (run-flag "l2t3_FAILED" true
               (test
@@ -302,7 +302,7 @@ describe 'AST optimization' do
           s(:object, "t1"),
           s(:id, "check_drb_completed"),
           s(:on_fail,
-            s(:set_run_flag, "check_drb_completed_FAILED"),
+            s(:set_run_flag, "check_drb_completed_FAILED", "auto_generated"),
             s(:continue))),
         s(:run_flag, "check_drb_completed_FAILED", true,
           s(:test,
@@ -314,7 +314,7 @@ describe 'AST optimization' do
               s(:set_result, "fail",
                 s(:bin, 204),
                 s(:softbin, 204)),
-              s(:set_run_flag,"check_prb1_new_FAILED"),
+              s(:set_run_flag,"check_prb1_new_FAILED", "auto_generated"),
               s(:continue))),
           s(:run_flag, "check_prb1_new_FAILED", true,
             s(:test,

--- a/spec/relationship_processor_spec.rb
+++ b/spec/relationship_processor_spec.rb
@@ -32,7 +32,7 @@ describe 'The Relationship Processor' do
           s(:name, "test1"),
           s(:id, :t1),
           s(:on_pass,
-            s(:set_run_flag, "t1_PASSED")),
+            s(:set_run_flag, "t1_PASSED", "auto_generated")),
           s(:on_fail,
             s(:continue))),
         s(:test,
@@ -41,9 +41,9 @@ describe 'The Relationship Processor' do
           s(:on_fail,
             s(:bin, 10),
             s(:continue),
-            s(:set_run_flag, "t2_FAILED")),
+            s(:set_run_flag, "t2_FAILED", "auto_generated")),
           s(:on_pass,
-            s(:set_run_flag, "t2_PASSED"))),
+            s(:set_run_flag, "t2_PASSED", "auto_generated"))),
         s(:run_flag, "t1_PASSED", true,
           s(:test,
             s(:name, "test3"))),
@@ -83,7 +83,7 @@ describe 'The Relationship Processor' do
           (object "test1")
           (id "ect1_1")
           (on-fail
-            (set-run-flag "ect1_1_FAILED")
+            (set-run-flag "ect1_1_FAILED" "auto_generated")
             (continue)))
         (run-flag "ect1_1_FAILED" true
           (test
@@ -92,7 +92,7 @@ describe 'The Relationship Processor' do
             (object "test3")
             (id "ect1_3")
             (on-fail
-              (set-run-flag "ect1_3_FAILED")
+              (set-run-flag "ect1_3_FAILED" "auto_generated")
               (continue)))
           (run-flag "ect1_3_FAILED" true
             (test
@@ -125,13 +125,13 @@ describe 'The Relationship Processor' do
           s(:object, "test1"),
           s(:id, "t1"),
           s(:on_fail,
-            s(:set_run_flag, "t1_FAILED"),
+            s(:set_run_flag, "t1_FAILED", "auto_generated"),
             s(:continue))),
         s(:test,
           s(:object, "test2"),
           s(:id, "t2"),
           s(:on_fail,
-            s(:set_run_flag, "t2_FAILED"),
+            s(:set_run_flag, "t2_FAILED", "auto_generated"),
             s(:continue))),
         s(:run_flag, ["t1_FAILED", "t2_FAILED"], true,
           s(:test,
@@ -172,7 +172,7 @@ describe 'The Relationship Processor' do
           (test
             (object "test2"))
           (on-fail
-            (set-run-flag "grp1_FAILED")
+            (set-run-flag "grp1_FAILED" "auto_generated")
             (continue)))
 
         (run-flag "grp1_FAILED" true
@@ -218,7 +218,7 @@ describe 'The Relationship Processor' do
           (test
             (object "test2"))
           (on-pass
-            (set-run-flag "grp1_PASSED"))
+            (set-run-flag "grp1_PASSED" "auto_generated"))
           (on-fail
             (continue)))
 


### PR DESCRIPTION
When a set-flag node in the relationship processor is created, add extra child, "auto_generated", that can be used by downstream processors to differentiate between user-defined flags and auto-generated ones.