### PR TITLE
Allow for mixed-case flags

### DIFF
--- a/lib/atp/ast/builder.rb
+++ b/lib/atp/ast/builder.rb
@@ -137,9 +137,9 @@ module ATP
           key = key.to_s.downcase.to_sym
           # Represent all condition values as lower cased strings internally
           if value.is_a?(Array)
-            value = value.map { |v| v.to_s.downcase }
+            value = value.map { |v| (v[0]=='!') ? v : v.to_s.downcase }
           else
-            value = value.to_s.downcase
+            value = (value[0]=='!') ? value : value.to_s.downcase
           end
           context[:conditions] << { key => value }
           case key

--- a/lib/atp/ast/builder.rb
+++ b/lib/atp/ast/builder.rb
@@ -137,9 +137,9 @@ module ATP
           key = key.to_s.downcase.to_sym
           # Represent all condition values as lower cased strings internally
           if value.is_a?(Array)
-            value = value.map { |v| (v[0]=='$') ? v : v.to_s.downcase }
+            value = value.map { |v| (v[0] == '$') ? v.to_s : v.to_s.downcase }
           else
-            value = (value[0]=='$') ? value : value.to_s.downcase
+            value = (value[0] == '$') ? value.to_s : value.to_s.downcase
           end
           context[:conditions] << { key => value }
           case key

--- a/lib/atp/ast/builder.rb
+++ b/lib/atp/ast/builder.rb
@@ -137,9 +137,9 @@ module ATP
           key = key.to_s.downcase.to_sym
           # Represent all condition values as lower cased strings internally
           if value.is_a?(Array)
-            value = value.map { |v| (v[0]=='!') ? v : v.to_s.downcase }
+            value = value.map { |v| (v[0]=='$') ? v : v.to_s.downcase }
           else
-            value = (value[0]=='!') ? value : value.to_s.downcase
+            value = (value[0]=='$') ? value : value.to_s.downcase
           end
           context[:conditions] << { key => value }
           case key


### PR DESCRIPTION
Updated the builder to accept a "!" as the initial character of flag.  Typical behavior is to lower-case all flag names when building the AST, but names with a leading ! will be placed into the structure unmolested.  In origen_testers, the output driver also recognizes the ! so that the flag name will be output without changing the capitalization.