### PR TITLE
Updated to handle true and false branches of a volatile flag...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 /.session
 /.pdm/pi_attributes.txt
 /.irb_history
+/.byebug_history
 
 # Cruft from other revision control systems
 .SYNC

--- a/lib/atp.rb
+++ b/lib/atp.rb
@@ -79,6 +79,7 @@ module ATP
     autoload :MissingIDs, 'atp/validators/missing_ids'
     autoload :Condition, 'atp/validators/condition'
     autoload :Jobs, 'atp/validators/jobs'
+    autoload :Flags, 'atp/validators/flags'
   end
 
   # Formatters are run on the processed AST to display the flow or to render

--- a/lib/atp/ast/node.rb
+++ b/lib/atp/ast/node.rb
@@ -86,6 +86,13 @@ module ATP
       def set_flags
         Processors::ExtractSetFlags.new.run(self)
       end
+
+      # Returns true if the node contains any nodes of the given type(s) of if any
+      # of its children do.
+      # To consider only direct children of this node use: node.find_all(*types).empty?
+      def contains?(*types)
+        !Extractor.new.process(self, types).empty?
+      end
     end
   end
 end

--- a/lib/atp/ast/node.rb
+++ b/lib/atp/ast/node.rb
@@ -87,7 +87,7 @@ module ATP
         Processors::ExtractSetFlags.new.run(self)
       end
 
-      # Returns true if the node contains any nodes of the given type(s) of if any
+      # Returns true if the node contains any nodes of the given type(s) or if any
       # of its children do.
       # To consider only direct children of this node use: node.find_all(*types).empty?
       def contains?(*types)

--- a/lib/atp/flow.rb
+++ b/lib/atp/flow.rb
@@ -121,6 +121,7 @@ module ATP
       Validators::DuplicateIDs.new(self).run(ast)
       Validators::MissingIDs.new(self).run(ast)
       Validators::Jobs.new(self).run(ast)
+      Validators::Flags.new(self).run(ast)
       # Ensure everything has an ID, this helps later if condition nodes need to be generated
       ast = Processors::AddIDs.new.run(ast) if options[:add_ids]
       ast = Processors::FlowID.new.run(ast, options[:unique_id]) if options[:unique_id]

--- a/lib/atp/processors/adjacent_if_combiner.rb
+++ b/lib/atp/processors/adjacent_if_combiner.rb
@@ -90,7 +90,7 @@ module ATP
       def safe_to_combine?(node1, node2)
         # Nodes won't be collapsed if node1 touches the shared run flag, i.e. if there is any chance
         # that by the time it would naturally execute node2, the flag could have been changed by node1
-        !volatile?(node1.to_a[0]) && !SetRunFlagFinder.new.contains?(node1, node1.to_a[0])
+        !SetRunFlagFinder.new.contains?(node1, node1.to_a[0])
       end
     end
   end

--- a/lib/atp/processors/adjacent_if_combiner.rb
+++ b/lib/atp/processors/adjacent_if_combiner.rb
@@ -90,7 +90,8 @@ module ATP
       def safe_to_combine?(node1, node2)
         # Nodes won't be collapsed if node1 touches the shared run flag, i.e. if there is any chance
         # that by the time it would naturally execute node2, the flag could have been changed by node1
-        !SetRunFlagFinder.new.contains?(node1, node1.to_a[0])
+        (!volatile?(node1.to_a[0]) || (volatile?(node1.to_a[0]) && !node1.contains?(:test))) &&
+          !SetRunFlagFinder.new.contains?(node1, node1.to_a[0])
       end
     end
   end

--- a/lib/atp/processors/flag_optimizer.rb
+++ b/lib/atp/processors/flag_optimizer.rb
@@ -74,11 +74,16 @@ module ATP
       alias_method :on_group, :on_named_collection
       alias_method :on_unless_flag, :on_named_collection
 
+      def on_unnamed_collection(node)
+        node.updated(nil, optimize(process_all(node.children)))
+      end
+      alias_method :on_else, :on_unnamed_collection
+
       def on_if_flag(node)
         name, *nodes = *node
         # Remove this node and return its children if required
         if if_run_flag_to_remove.last == node.to_a[0]
-          node.updated(:inline, node.to_a[1..-1])
+          node.updated(:inline, optimize(process_all(node.to_a[1..-1])))
         else
           node.updated(nil, [name] + optimize(process_all(nodes)))
         end
@@ -148,7 +153,7 @@ module ATP
       end
 
       def combine(node1, node2)
-        nodes_to_inline_on_pass_or_fail << node2
+        nodes_to_inline_on_pass_or_fail << node2 # .updated(nil, process_all(node2.children))
         node1 = node1.updated(nil, process_all(node1.children))
         nodes_to_inline_on_pass_or_fail.pop
         node1

--- a/lib/atp/processors/relationship.rb
+++ b/lib/atp/processors/relationship.rb
@@ -119,6 +119,7 @@ module ATP
       # Set flags depending on the result on tests which have dependents later
       # in the flow
       def on_test(node)
+        node = node.updated(nil, process_all(node.children))
         nid = id(node)
         # If this test has a dependent
         if test_results[nid]
@@ -126,11 +127,7 @@ module ATP
           node = add_fail_flag(nid, node) if test_results[nid][:failed]
           node = add_ran_flags(nid, node) if test_results[nid][:ran]
         end
-        if node.type == :group
-          node.updated(nil, process_all(node))
-        else
-          node
-        end
+        node
       end
       alias_method :on_group, :on_test
 

--- a/lib/atp/validators/flags.rb
+++ b/lib/atp/validators/flags.rb
@@ -1,0 +1,59 @@
+module ATP
+  module Validators
+    class Flags < Validator
+      def setup
+        @open_if_nodes = []
+        @open_unless_nodes = []
+        @conflicting = []
+      end
+
+      def on_completion
+        failed = false
+        unless @conflicting.empty?
+          error 'if_flag and unless_flag conditions cannot be nested and refer to the same flag unless it is declared as volatile'
+          error "The following conflicts were found in flow #{flow.name}:"
+          @conflicting.each do |a, b|
+            a_condition = a.to_a[1] ? 'if_job:    ' : 'unless_job:'
+            b_condition = b.to_a[1] ? 'if_job:    ' : 'unless_job:'
+            error "  #{a.type}(#{a.to_a[0]}) #{a.source}"
+            error "  #{b.type}(#{b.to_a[0]}) #{b.source}"
+            error ''
+          end
+          failed = true
+        end
+        failed
+      end
+
+      def on_flow(node)
+        extract_volatiles(node)
+        process_all(node.children)
+      end
+
+      def on_if_flag(node)
+        if volatile?(node.to_a[0])
+          process_all(node.children)
+        else
+          if n = @open_unless_nodes.find { |n| n.to_a[0] == node.to_a[0] }
+            @conflicting << [n, node]
+          end
+          @open_if_nodes << node
+          process_all(node.children)
+          @open_if_nodes.pop
+        end
+      end
+
+      def on_unless_flag(node)
+        if volatile?(node.to_a[0])
+          process_all(node.children)
+        else
+          if n = @open_if_nodes.find { |n| n.to_a[0] == node.to_a[0] }
+            @conflicting << [n, node]
+          end
+          @open_unless_nodes << node
+          process_all(node.children)
+          @open_unless_nodes.pop
+        end
+      end
+    end
+  end
+end

--- a/spec/optimization_spec.rb
+++ b/spec/optimization_spec.rb
@@ -454,4 +454,79 @@ describe 'general AST optimization test cases' do
               s(:test,
                 s(:object, "test2"))))))
   end
+
+  it "A test case where the nested if_failed flag wasn't rendering" do
+    test :test1, id: :t1, on_fail: ->{
+      if_flag "TestFlag" do
+        bin 1
+      end
+      unless_flag "TestFlag" do
+        test :test2, id: :t2, on_fail: ->{
+          if_flag "TestFlag" do
+            bin 1
+          end
+        }
+        unless_flag "TestFlag" do
+          bin 2, if_failed: :t2
+        end
+      end
+    }
+
+    ast.should ==
+      s(:flow,
+        s(:name, "sort1"),
+        s(:test,
+          s(:object, "test1"),
+          s(:id, "t1"),
+          s(:on_fail,
+            s(:if_flag, "TestFlag",
+              s(:set_result, "fail",
+                s(:bin, 1)),
+              s(:else,
+                s(:test,
+                  s(:object, "test2"),
+                  s(:id, "t2"),
+                  s(:on_fail,
+                    s(:if_flag, "TestFlag",
+                      s(:set_result, "fail",
+                        s(:bin, 1))))),
+                s(:if_failed, "t2",
+                  s(:set_result, "fail",
+                    s(:bin, 2))))))))
+  end
+
+  it "A test case where the if_passed/if_failed wasn't rendering properly" do
+    test :test1, id: :t1
+    if_failed :t1, then: ->{
+      bin 2
+    }, else: ->{
+      if_flag "TestFlag", then: ->{ bin 1 }, else: ->{
+        test :test2, id: :t2
+        bin 3, if_failed: :t2
+      }
+    }
+    
+    ast.should ==
+      s(:flow,
+        s(:name, "sort1"),
+        s(:test,
+          s(:object, "test1"),
+          s(:id, "t1"),
+          s(:on_fail,
+            s(:set_result, "fail",
+              s(:bin, 2)),
+            s(:else,
+              s(:if_flag, "TestFlag",
+                s(:set_result, "fail",
+                  s(:bin, 1)),
+                s(:else,
+                  s(:test,
+                    s(:object, "test2"),
+                    s(:id, "t2"),
+                    s(:on_fail,
+                      s(:set_flag, "t2_FAILED", "auto_generated"))),
+                  s(:if_flag, "t2_FAILED",
+                    s(:set_result, "fail",
+                      s(:bin, 3)))))))))
+  end
 end


### PR DESCRIPTION
…without generating multiple flag checks.

A code structure like
```
if_passed :flagname do
  bin 1
end
if_failed :flagname do
  bin 2
end

```
should still combine to an if/else structure even if :flagname is declared as volatile.  Currently the code generates two back-to-back flag comparisons with opposite value states.
