### PR TITLE
Added in ids method for the ATP Flow

### DIFF
--- a/lib/atp/flow.rb
+++ b/lib/atp/flow.rb
@@ -464,7 +464,7 @@ module ATP
       "<ATP::Flow:#{object_id} #{name}>"
     end
 
-    def ids
+    def ids(options = {})
       ATP::AST::Extractor.new.process(raw, [:id]).map { |node| node.to_a[0] }
     end
 

--- a/lib/atp/flow.rb
+++ b/lib/atp/flow.rb
@@ -464,6 +464,10 @@ module ATP
       "<ATP::Flow:#{object_id} #{name}>"
     end
 
+    def ids
+      ATP::AST::Extractor.new.process(raw, [:id]).map { |node| node.to_a[0] }
+    end
+
     private
 
     def flow_control_method(name, flag, options = {}, &block)

--- a/lib/atp/flow_api.rb
+++ b/lib/atp/flow_api.rb
@@ -17,7 +17,7 @@ module ATP
         add_meta!(options) if respond_to?(:add_meta!, true)
         add_description!(options) if respond_to?(:add_description!, true)
         args << options
-        [:ids].include?(method) ? atp.send(method) : atp.send(method, *args, &block)
+        atp.send(method, *args, &block)
       end
     end
 

--- a/lib/atp/flow_api.rb
+++ b/lib/atp/flow_api.rb
@@ -9,7 +9,7 @@ module ATP
     end
 
     ([:test, :bin, :pass, :continue, :cz, :log, :sub_test, :volatile, :set_flag, :enable, :disable, :render,
-      :context_changed?] +
+      :context_changed?, :ids] +
       ATP::Flow::CONDITION_KEYS.keys).each do |method|
       define_method method do |*args, &block|
         options = args.pop if args.last.is_a?(Hash)
@@ -17,7 +17,7 @@ module ATP
         add_meta!(options) if respond_to?(:add_meta!, true)
         add_description!(options) if respond_to?(:add_description!, true)
         args << options
-        atp.send(method, *args, &block)
+        [:ids].include?(method) ? atp.send(method) : atp.send(method, *args, &block)
       end
     end
 

--- a/spec/flow_spec.rb
+++ b/spec/flow_spec.rb
@@ -314,5 +314,14 @@ describe 'The flow builder API' do
         context_changed?(if_enable: 'blah').should == false
       end
     end
+    
+    it 'can return a list of test IDs used within the flow' do
+      atp.ids.should == []
+      test :test1, id: :t1
+      test :test2, id: "T2"
+      test :test3, id: "t1"
+      atp.ids.should == ['t1', 'T2', 't1']
+      atp.ids.should == ids
+    end
   end
 end


### PR DESCRIPTION
~~~ruby
    it 'can return a list of test IDs used within the flow' do
      atp.ids.should == []
      test :test1, id: :t1
      test :test2, id: "T2"
      test :test3, id: "t1"
      atp.ids.should == ['t1', 'T2', 't1']
      atp.ids.should == ids
    end
~~~