### PR TITLE
Allow over_on option to be specified for on_result

### DIFF
--- a/lib/atp/flow.rb
+++ b/lib/atp/flow.rb
@@ -255,6 +255,10 @@ module ATP
             options[:on_fail] ||= {}
             options[:on_fail][:bin_description] = b
           end
+          if b = options.delete(:bin_attrs)
+            options[:on_fail] ||= {}
+            options[:on_fail][:bin_attrs] = b
+          end
           if b = options.delete(:softbin) || b = options.delete(:sbin) || b = options.delete(:soft_bin)
             options[:on_fail] ||= {}
             options[:on_fail][:softbin] = b
@@ -262,10 +266,6 @@ module ATP
           if b = options.delete(:softbin_description) || options.delete(:sbin_description) || options.delete(:soft_bin_description)
             options[:on_fail] ||= {}
             options[:on_fail][:softbin_description] = b
-          end
-          if options.delete(:not_over_on)
-            options[:on_fail] ||= {}
-            options[:on_fail][:not_over_on] = true
           end
           if options.delete(:continue)
             options[:on_fail] ||= {}
@@ -704,7 +704,7 @@ module ATP
           fail_opts = { bin: options[:bin], softbin: options[:softbin] }
           fail_opts[:bin_description] = options[:bin_description] if options[:bin_description]
           fail_opts[:softbin_description] = options[:softbin_description] if options[:softbin_description]
-          fail_opts[:not_over_on] = options[:not_over_on] if options[:not_over_on]
+          fail_opts[:bin_attrs] = options[:bin_attrs] if options[:bin_attrs]
           children << set_result(:fail, fail_opts)
         end
         if options[:set_run_flag] || options[:set_flag]
@@ -727,7 +727,7 @@ module ATP
           pass_opts = { bin: options[:bin], softbin: options[:softbin] }
           pass_opts[:bin_description] = options[:bin_description] if options[:bin_description]
           pass_opts[:softbin_description] = options[:softbin_description] if options[:softbin_description]
-          pass_opts[:not_over_on] = options[:not_over_on] if options[:not_over_on]
+          pass_opts[:bin_attrs] = options[:bin_attrs] if options[:bin_attrs]
           children << set_result(:pass, pass_opts)
         end
         if options[:set_run_flag] || options[:set_flag]
@@ -776,8 +776,10 @@ module ATP
       else
         children << n1(:softbin, options[:softbin]) if options[:softbin]
       end
-      if options[:not_over_on]
-        children << n1(:not_over_on, options[:not_over_on])
+      if options[:bin_attrs]
+        options[:bin_attrs].each do |key, val|
+          children << n1(key, val)
+        end
       end
       n(:set_result, children)
     end

--- a/lib/atp/flow.rb
+++ b/lib/atp/flow.rb
@@ -263,6 +263,10 @@ module ATP
             options[:on_fail] ||= {}
             options[:on_fail][:softbin_description] = b
           end
+          if options.delete(:not_over_on)
+            options[:on_fail] ||= {}
+            options[:on_fail][:not_over_on] = true
+          end
           if options.delete(:continue)
             options[:on_fail] ||= {}
             options[:on_fail][:continue] = true
@@ -700,6 +704,7 @@ module ATP
           fail_opts = { bin: options[:bin], softbin: options[:softbin] }
           fail_opts[:bin_description] = options[:bin_description] if options[:bin_description]
           fail_opts[:softbin_description] = options[:softbin_description] if options[:softbin_description]
+          fail_opts[:not_over_on] = options[:not_over_on] if options[:not_over_on]
           children << set_result(:fail, fail_opts)
         end
         if options[:set_run_flag] || options[:set_flag]
@@ -722,6 +727,7 @@ module ATP
           pass_opts = { bin: options[:bin], softbin: options[:softbin] }
           pass_opts[:bin_description] = options[:bin_description] if options[:bin_description]
           pass_opts[:softbin_description] = options[:softbin_description] if options[:softbin_description]
+          pass_opts[:not_over_on] = options[:not_over_on] if options[:not_over_on]
           children << set_result(:pass, pass_opts)
         end
         if options[:set_run_flag] || options[:set_flag]
@@ -769,6 +775,9 @@ module ATP
         children << n2(:softbin, options[:softbin], options[:softbin_description])
       else
         children << n1(:softbin, options[:softbin]) if options[:softbin]
+      end
+      if options[:not_over_on]
+        children << n1(:not_over_on, options[:not_over_on])
       end
       n(:set_result, children)
     end

--- a/spec/flow_spec.rb
+++ b/spec/flow_spec.rb
@@ -296,6 +296,46 @@ describe 'The flow builder API' do
       end
     end
 
+    it "atp.test with not_over_on" do
+      test("test1", bin: 1, softbin: 10)
+      test("test2", bin: 2, softbin: 20, not_over_on: true)
+   
+      atp.raw.should ==
+        s(:flow,
+          s(:name, "sort1"),
+          s(:test,
+            s(:object, "test1"),
+            s(:on_fail,
+              s(:set_result, "fail",
+                s(:bin, 1),
+                s(:softbin, 10)))),
+          s(:test,
+            s(:object, "test2"),
+            s(:on_fail,
+              s(:set_result, "fail",
+                s(:bin, 2),
+                s(:softbin, 20),
+                s(:not_over_on, true)))))
+      
+      atp.raw.find_all(:test).each do |test_node|
+        set_result_node = test_node.find(:on_fail).find(:set_result)
+        case test_node.find(:object).try(:value)
+          when 'test1'
+            set_result_node.find(:bin).try(:value).should == 1
+            set_result_node.find(:bin).to_a[1].should == nil
+            set_result_node.find(:softbin).try(:value).should == 10
+            set_result_node.find(:softbin).to_a[1].should == nil
+            set_result_node.find(:not_over_on).try(:value) == nil
+          when 'test2'
+            set_result_node.find(:bin).try(:value).should == 2
+            set_result_node.find(:bin).to_a[1].should == nil
+            set_result_node.find(:softbin).try(:value).should == 20
+            set_result_node.find(:softbin).to_a[1].should == nil
+            set_result_node.find(:not_over_on).try(:value) == true
+        end
+      end
+    end
+
     it "atp.cz with enable words" do
       if_enable :cz do
         cz :test1, :cz1

--- a/spec/flow_spec.rb
+++ b/spec/flow_spec.rb
@@ -298,7 +298,7 @@ describe 'The flow builder API' do
 
     it "atp.test with not_over_on" do
       test("test1", bin: 1, softbin: 10)
-      test("test2", bin: 2, softbin: 20, not_over_on: true)
+      test("test2", bin: 2, softbin: 20, bin_attrs: { not_over_on: true })
    
       atp.raw.should ==
         s(:flow,

--- a/spec/test_node_spec.rb
+++ b/spec/test_node_spec.rb
@@ -13,6 +13,9 @@ describe 'Test nodes' do
 
   it "can capture limit information" do
     test :test1, limits: [{ value: 5, rule: :lte}, { value: 1, rule: :gt, units: :mV }]
+    test :test2, limits: :none
+    test :test3, high: 5
+    test :test4, low: 22
 
     ast.should ==
        s(:flow,
@@ -20,7 +23,16 @@ describe 'Test nodes' do
          s(:test,
            s(:object, "test1"),
            s(:limit, 5, "lte", nil, nil),
-           s(:limit, 1, "gt", "mV", nil)))
+           s(:limit, 1, "gt", "mV", nil)),
+         s(:test,
+           s(:object, "test2"),
+           s(:nolimits)),
+         s(:test,
+           s(:object, "test3"),
+           s(:limit, 5, "lte", nil, nil)),
+         s(:test,
+           s(:object, "test4"),
+           s(:limit, 22, "gte", nil, nil)))
   end
 
   it "can capture target pin information" do


### PR DESCRIPTION
Include 'over_on' option in set_result node (if specified) so it can be picked up later during flow generation for V93K.


To be paired with following code in origen_testers:
```
overon = (node.find(:not_over_on).try(:value) == true) ? 'not_over_on' : 'over_on'

if node.to_a[0] == 'pass'
  line "stop_bin \"#{sbin}\", \"\", , good, noreprobe, green, #{bin}, #{overon};"
else
  if tester.create_limits_file
    line 'multi_bin;'
  else
    line "stop_bin \"#{sbin}\", \"#{sdesc}\", , bad, noreprobe, red, #{bin}, #{overon};"
  end
end
```

