### PR TITLE
Add support for non-Boolean flow variables

### DIFF
--- a/lib/atp.rb
+++ b/lib/atp.rb
@@ -39,7 +39,8 @@ module ATP
          :unless_failed, :passed, :if_ran, :if_executed, :unless_ran, :unless_executed, :job,
          :jobs, :if_job, :if_jobs, :unless_job, :unless_jobs, :if_any_failed, :unless_all_passed,
          :if_all_failed, :unless_any_passed, :if_any_passed, :unless_all_failed, :if_all_passed,
-         :unless_any_failed, :if_flag, :unless_flag]
+         :unless_any_failed, :if_flag, :unless_flag, :if_var, :if_variable, :if_variables,
+         :unless_var, :unless_variable, :unless_variables]
       end
     end
   end

--- a/lib/atp/flow.rb
+++ b/lib/atp/flow.rb
@@ -515,7 +515,6 @@ module ATP
     # been defined above
     CONDITION_KEYS.keys.each do |method|
       define_method method do |*flags, &block|
-        puts flags
         if flags.last.is_a?(Hash)
           options = flags.pop
         else

--- a/lib/atp/flow.rb
+++ b/lib/atp/flow.rb
@@ -67,7 +67,7 @@ module ATP
     }
 
     CONDITION_NODE_TYPES = CONDITION_KEYS.values.uniq
-    
+
     VARIABLE_CONDITION_KEYS = [:if_var, :if_vaiable, :if_vaiables, :unless_var, :unless_variable, :unless_variables]
 
     def initialize(program, name = nil, options = {})
@@ -202,7 +202,7 @@ module ATP
     end
 
     # Indicate the that given flags should be considered volatile (can change at any time), which will
-    # prevent them from been touched by the optimization algorithms
+    # prevent them from being touched by the optimization algorithms
     def volatile(*flags)
       options = flags.pop if flags.last.is_a?(Hash)
       flags = flags.flatten
@@ -515,6 +515,7 @@ module ATP
     # been defined above
     CONDITION_KEYS.keys.each do |method|
       define_method method do |*flags, &block|
+        puts flags
         if flags.last.is_a?(Hash)
           options = flags.pop
         else

--- a/lib/atp/flow.rb
+++ b/lib/atp/flow.rb
@@ -55,10 +55,20 @@ module ATP
 
       unless_flag:       :unless_flag,
 
+      if_var:            :if_var,
+      if_vaiable:        :if_var,
+      if_vaiables:       :if_var,
+
+      unless_var:        :unless_var,
+      unless_variable:   :unless_var,
+      unless_variables:  :unless_var,
+
       group:             :group
     }
 
     CONDITION_NODE_TYPES = CONDITION_KEYS.values.uniq
+    
+    VARIABLE_CONDITION_KEYS = [:if_var, :if_vaiable, :if_vaiables, :unless_var, :unless_variable, :unless_variables]
 
     def initialize(program, name = nil, options = {})
       name, options = nil, name if name.is_a?(Hash)
@@ -141,6 +151,9 @@ module ATP
         end
         if options[:optimize_flags]
           ast = Processors::FlagOptimizer.new.run(ast, optimize_when_continue: options[:optimize_flags_when_continue])
+        end
+        if options[:optimize_variables]
+          ast = Processors::VariableOptimizer.new.run(ast, optimize_when_continue: options[:optimize_variables_when_continue])
         end
         ast = Processors::AdjacentIfCombiner.new.run(ast)
 
@@ -654,7 +667,7 @@ module ATP
           if conditions[key] && value
             fail "Multiple values assigned to flow condition #{key}" unless conditions[key] == value
           else
-            conditions[key] = value if value
+            conditions[key] = (value.is_a?(Hash) ? [value] : value) if value
           end
         end
       end

--- a/lib/atp/flow.rb
+++ b/lib/atp/flow.rb
@@ -56,8 +56,8 @@ module ATP
       unless_flag:       :unless_flag,
 
       if_var:            :if_var,
-      if_vaiable:        :if_var,
-      if_vaiables:       :if_var,
+      if_variable:       :if_var,
+      if_variables:      :if_var,
 
       unless_var:        :unless_var,
       unless_variable:   :unless_var,
@@ -68,7 +68,7 @@ module ATP
 
     CONDITION_NODE_TYPES = CONDITION_KEYS.values.uniq
 
-    VARIABLE_CONDITION_KEYS = [:if_var, :if_vaiable, :if_vaiables, :unless_var, :unless_variable, :unless_variables]
+    VARIABLE_CONDITION_KEYS = [:if_var, :if_variable, :if_variables, :unless_var, :unless_variable, :unless_variables]
 
     def initialize(program, name = nil, options = {})
       name, options = nil, name if name.is_a?(Hash)

--- a/lib/atp/flow_api.rb
+++ b/lib/atp/flow_api.rb
@@ -18,7 +18,7 @@ module ATP
             fail 'variable conditional only accepts Hash or Array of Hashes as first argument'
           end
           if args.first.is_a?(Hash)
-            single = args.shift #if args.first.is_a?(Hash)
+            single = args.shift
             single_ary = [single]
             args.insert(0, single_ary)
           else

--- a/lib/atp/flow_api.rb
+++ b/lib/atp/flow_api.rb
@@ -12,6 +12,22 @@ module ATP
       :context_changed?, :ids, :describe_bin, :describe_softbin, :describe_soft_bin] +
       ATP::Flow::CONDITION_KEYS.keys).each do |method|
       define_method method do |*args, &block|
+        # for variable conditions, only accept hash or array of hashes for first arg
+        if ATP::Flow::VARIABLE_CONDITION_KEYS.include?(method)
+          unless args.first.is_a?(Hash) || args.first.is_a?(Array)
+            fail 'variable conditional only accepts Hash or Array of Hashes as first argument'
+          end
+          if args.first.is_a?(Hash)
+            single = args.shift #if args.first.is_a?(Hash)
+            single_ary = [single]
+            args.insert(0, single_ary)
+          else
+            args.first.each do |v|
+              fail 'variable conditional only accepts Hash or Array of Hashes as first argument' unless v.is_a?(Hash)
+            end
+          end
+        end
+
         options = args.pop if args.last.is_a?(Hash)
         options ||= {}
         add_meta!(options) if respond_to?(:add_meta!, true)

--- a/lib/atp/processors/variable_optimizer.rb
+++ b/lib/atp/processors/variable_optimizer.rb
@@ -1,0 +1,22 @@
+module ATP
+  module Processors
+    class VariableOptimizer < Processor
+      attr_reader :optimize_when_continue
+
+      def run(node, options = {})
+        options = {
+          optimize_when_continue: true
+        }.merge(options)
+        @optimize_when_continue = options[:optimize_when_continue]
+
+        # Pre-process the AST for # of occurrences of each run-flag used
+        # t = ExtractRunFlagTable.new
+        # t.process(node)
+        # @run_flag_table = t.run_flag_table
+        # extract_volatiles(node)
+        # process(node)
+        node
+      end
+    end
+  end
+end

--- a/lib/atp/runner.rb
+++ b/lib/atp/runner.rb
@@ -49,6 +49,11 @@ module ATP
     end
     alias_method :on_unless_flag, :on_if_flag
 
+    def on_if_var(node)
+      # TODO: implement if var runner code
+    end
+    alias_method :on_unless_var, :on_if_var
+
     def on_if_enabled(node)
       if @options[:evaluate_enables]
         flag, *nodes = *node

--- a/spec/condition_processor_spec.rb
+++ b/spec/condition_processor_spec.rb
@@ -644,4 +644,31 @@ describe 'The Condition Processor' do
         s(:test,
           s(:object, "test3")))
   end
+
+  it "variable conditions work" do
+    if_var({var1: 'VAL1'}) do 
+      test :test1
+    end
+    unless_var [{var2: 'VAL2'}] do 
+      test :test2
+    end
+    if_var [{var1: 'VAL3'},{var2: 'VAL4'}] do 
+      test :test3
+    end
+
+    atp.raw.should ==
+      s(:flow,
+        s(:name, "sort1"),
+        s(:if_var, [{:var1=>"VAL1"}],
+          s(:test,
+            s(:object, "test1"))),
+        s(:unless_var, [{:var2=>"VAL2"}],
+          s(:test,
+            s(:object, "test2"))),
+        s(:if_var, [{:var1=>"VAL3"}, {:var2=>"VAL4"}],
+          s(:test,
+            s(:object, "test3"))))
+
+
+  end
 end

--- a/spec/flow_spec.rb
+++ b/spec/flow_spec.rb
@@ -296,7 +296,7 @@ describe 'The flow builder API' do
       end
     end
 
-    it "atp.test with not_over_on" do
+    it "atp.test with bin attributes" do
       test("test1", bin: 1, softbin: 10)
       test("test2", bin: 2, softbin: 20, bin_attrs: { not_over_on: true })
    

--- a/spec/flow_spec.rb
+++ b/spec/flow_spec.rb
@@ -446,5 +446,21 @@ describe 'The flow builder API' do
               s(:set_result, "fail",
                 s(:bin, 10)))))
     end
+
+    it 'can handle source file and line number' do
+      test("test1", bin: 1, softbin: 10, continue: true, source_file: '/path/to/program/file', source_line_number: 22)
+      atp.ast.should ==
+        s(:flow,
+          s(:name, "sort1"),
+          s(:test,
+            s(:object, "test1"),
+            s(:on_fail,
+              s(:set_result, "fail",
+                s(:bin, 1),
+                s(:softbin, 10)),
+              s(:continue)),
+            s(:id, "t1")))
+
+    end
   end
 end


### PR DESCRIPTION
The 93K tester can use string-based variables for flow control.  This PR add support for these variables by extending the existing enables/flags implementation with optional Hash structure to specify/track the variable=value relationships. 