### PR TITLE
Add support for non-Boolean flow variables (UPDATED)

### DIFF
--- a/lib/atp.rb
+++ b/lib/atp.rb
@@ -39,7 +39,7 @@ module ATP
          :unless_failed, :passed, :if_ran, :if_executed, :unless_ran, :unless_executed, :job,
          :jobs, :if_job, :if_jobs, :unless_job, :unless_jobs, :if_any_failed, :unless_all_passed,
          :if_all_failed, :unless_any_passed, :if_any_passed, :unless_all_failed, :if_all_passed,
-         :unless_any_failed, :if_flag, :unless_flag]
+         :unless_any_failed, :if_flag, :unless_flag, :if_true, :if_false]
       end
     end
   end

--- a/lib/atp.rb
+++ b/lib/atp.rb
@@ -39,7 +39,7 @@ module ATP
          :unless_failed, :passed, :if_ran, :if_executed, :unless_ran, :unless_executed, :job,
          :jobs, :if_job, :if_jobs, :unless_job, :unless_jobs, :if_any_failed, :unless_all_passed,
          :if_all_failed, :unless_any_passed, :if_any_passed, :unless_all_failed, :if_all_passed,
-         :unless_any_failed, :if_flag, :unless_flag, :if_true, :if_false]
+         :unless_any_failed, :if_flag, :unless_flag, :whenever, :whenever_all, :whenever_any]
       end
     end
   end

--- a/lib/atp/flow.rb
+++ b/lib/atp/flow.rb
@@ -474,6 +474,14 @@ module ATP
       end
     end
 
+    def set(var, val, options = {})
+      extract_meta!(options) do
+        apply_conditions(options) do
+          set_node(var, val)
+        end
+      end
+    end
+
     # Insert explicitly rendered content in to the flow
     def render(str, options = {})
       extract_meta!(options) do
@@ -511,6 +519,24 @@ module ATP
         options = {}
       end
       flow_control_method(:whenever, expressions, options, &block)
+    end
+
+    def loop(*args, &block)
+      unless args[0].keys.include?(:from) && args[0].keys.include?(:to) && args[0].keys.include?(:step)
+        fail 'Loop must specify :from, :to, :step'
+      end
+      extract_meta!(options) do
+        apply_conditions(options) do
+          params = []
+          params << args[0][:from]
+          params << args[0][:to]
+          params << args[0][:step]
+          params << args[0][:var] if args[0].keys.include?(:var)
+          node = n(:loop, params)
+          node = append_to(node) { block.call }
+          node
+        end
+      end
     end
 
     RELATIONAL_OPERATORS.each do |method|
@@ -815,6 +841,10 @@ module ATP
 
     def set_flag_node(flag)
       n1(:set_flag, flag)
+    end
+
+    def set_node(var, val)
+      n2(:set, var, val)
     end
 
     # Ensures the flow ast has a volatile node, then adds the

--- a/lib/atp/flow.rb
+++ b/lib/atp/flow.rb
@@ -55,8 +55,9 @@ module ATP
 
       unless_flag:       :unless_flag,
 
-      if_true:           :if_true,
-      if_false:          :if_true,
+      whenever:          :whenever,
+      whenever_all:      :whenever_all,
+      whenever_any:      :whenever_any,
 
       group:             :group
     }
@@ -503,38 +504,13 @@ module ATP
       last_conditions != clean_conditions(open_conditions + [extract_conditions(options)])
     end
 
-    def if_true(*expressions, &block)
+    def whenever(*expressions, &block)
       if expressions.last.is_a?(Hash)
         options = expressions.pop
       else
         options = {}
       end
-      flow_control_method(:if_true, expressions, options, &block)
-    end
-
-    def if_false(*expressions, &block)
-      if expressions.last.is_a?(Hash)
-        options = expressions.pop
-      else
-        options = {}
-      end
-      flow_control_method(:if_false, expressions, options, &block)
-    end
-
-    def expr(*args, &block)
-      options = args.pop if args.last.is_a?(Hash)
-      if args[0] == :or || args[0] == :and
-        operator = args.delete_at(0)
-        n(operator, args)
-      else
-        unless RELATIONAL_OPERATORS.include? args[0]
-          fail "Legal relational operators for expr are: #{RELATIONAL_OPERATORS}"
-        end
-        unless args.size == 3
-          fail 'Format for expr must match (var1, relational operator, var2)'
-        end
-        n2(args[0], args[1], args[2])
-      end
+      flow_control_method(:whenever, expressions, options, &block)
     end
 
     RELATIONAL_OPERATORS.each do |method|

--- a/lib/atp/flow.rb
+++ b/lib/atp/flow.rb
@@ -531,7 +531,7 @@ module ATP
           fail "Legal relational operators for expr are: #{RELATIONAL_OPERATORS}"
         end
         unless args.size == 3
-          fail "Format for expr must match (var1, relational operator, var2)"
+          fail 'Format for expr must match (var1, relational operator, var2)'
         end
         n2(args[1], args[0], args[2])
       end

--- a/lib/atp/flow.rb
+++ b/lib/atp/flow.rb
@@ -477,7 +477,7 @@ module ATP
     def set(var, val, options = {})
       extract_meta!(options) do
         apply_conditions(options) do
-          set_node(var, val)
+          n2(:set, var, val)
         end
       end
     end
@@ -527,11 +527,10 @@ module ATP
       end
       extract_meta!(options) do
         apply_conditions(options) do
-          params = []
-          params << args[0][:from]
-          params << args[0][:to]
-          params << args[0][:step]
-          params << args[0][:var] if args[0].keys.include?(:var)
+          # always pass 4-element array to loop node to simplify downstream parser
+          #   last element, 'var', will be nil if not specified by loop call
+          params = [args[0][:from], args[0][:to], args[0][:step], args[0][:var]]
+
           node = n(:loop, params)
           node = append_to(node) { block.call }
           node
@@ -841,10 +840,6 @@ module ATP
 
     def set_flag_node(flag)
       n1(:set_flag, flag)
-    end
-
-    def set_node(var, val)
-      n2(:set, var, val)
     end
 
     # Ensures the flow ast has a volatile node, then adds the

--- a/lib/atp/flow.rb
+++ b/lib/atp/flow.rb
@@ -527,13 +527,13 @@ module ATP
         operator = args.delete_at(0)
         n(operator, args)
       else
-        unless RELATIONAL_OPERATORS.include? args[1]
+        unless RELATIONAL_OPERATORS.include? args[0]
           fail "Legal relational operators for expr are: #{RELATIONAL_OPERATORS}"
         end
         unless args.size == 3
           fail 'Format for expr must match (var1, relational operator, var2)'
         end
-        n2(args[1], args[0], args[2])
+        n2(args[0], args[1], args[2])
       end
     end
 

--- a/lib/atp/flow_api.rb
+++ b/lib/atp/flow_api.rb
@@ -10,7 +10,7 @@ module ATP
 
     ([:test, :bin, :pass, :continue, :cz, :log, :sub_test, :volatile, :set_flag, :enable, :disable, :render,
       :context_changed?, :ids, :describe_bin, :describe_softbin, :describe_soft_bin] +
-      ATP::Flow::CONDITION_KEYS.keys).each do |method|
+      ATP::Flow::CONDITION_KEYS.keys + ATP::Flow::RELATIONAL_OPERATORS + [:expr]).each do |method|
       define_method method do |*args, &block|
         options = args.pop if args.last.is_a?(Hash)
         options ||= {}

--- a/lib/atp/flow_api.rb
+++ b/lib/atp/flow_api.rb
@@ -8,8 +8,8 @@ module ATP
       @atp
     end
 
-    ([:test, :bin, :pass, :continue, :cz, :log, :sub_test, :volatile, :set_flag, :enable, :disable, :render,
-      :context_changed?, :ids, :describe_bin, :describe_softbin, :describe_soft_bin] +
+    ([:test, :bin, :pass, :continue, :cz, :log, :sub_test, :volatile, :set_flag, :set, :enable, :disable, :render,
+      :context_changed?, :ids, :describe_bin, :describe_softbin, :describe_soft_bin, :loop] +
       ATP::Flow::CONDITION_KEYS.keys + ATP::Flow::RELATIONAL_OPERATORS).each do |method|
       define_method method do |*args, &block|
         options = args.pop if args.last.is_a?(Hash)

--- a/lib/atp/flow_api.rb
+++ b/lib/atp/flow_api.rb
@@ -10,7 +10,7 @@ module ATP
 
     ([:test, :bin, :pass, :continue, :cz, :log, :sub_test, :volatile, :set_flag, :enable, :disable, :render,
       :context_changed?, :ids, :describe_bin, :describe_softbin, :describe_soft_bin] +
-      ATP::Flow::CONDITION_KEYS.keys + ATP::Flow::RELATIONAL_OPERATORS + [:expr]).each do |method|
+      ATP::Flow::CONDITION_KEYS.keys + ATP::Flow::RELATIONAL_OPERATORS).each do |method|
       define_method method do |*args, &block|
         options = args.pop if args.last.is_a?(Hash)
         options ||= {}

--- a/lib/atp/processors/flag_optimizer.rb
+++ b/lib/atp/processors/flag_optimizer.rb
@@ -79,10 +79,12 @@ module ATP
       end
       alias_method :on_else, :on_unnamed_collection
 
-      def on_if_true(node)
+      def on_whenever(node)
         name, *nodes = *node
         node.updated(nil, [name] + optimize(process_all(nodes)))
       end
+      alias_method :on_whenever_all, :on_whenever
+      alias_method :on_whenever_any, :on_whenever
 
       def on_if_flag(node)
         name, *nodes = *node

--- a/lib/atp/processors/flag_optimizer.rb
+++ b/lib/atp/processors/flag_optimizer.rb
@@ -79,6 +79,11 @@ module ATP
       end
       alias_method :on_else, :on_unnamed_collection
 
+      def on_if_true(node)
+        name, *nodes = *node
+        node.updated(nil, [name] + optimize(process_all(nodes)))
+      end
+
       def on_if_flag(node)
         name, *nodes = *node
         # Remove this node and return its children if required

--- a/spec/flow_spec.rb
+++ b/spec/flow_spec.rb
@@ -446,5 +446,31 @@ describe 'The flow builder API' do
               s(:set_result, "fail",
                 s(:bin, 10)))))
     end
+
+    it 'can enable and disable flow control variables' do
+      self.atp = ATP::Program.new.flow(:sort1) 
+
+      enable :run_flag_1
+      if_enabled :run_flag_1 do
+        test :test_should_run
+      end
+
+      disable :run_flag_2
+      if_enabled :run_flag_2 do
+        test :test_should_not_run
+      end
+
+      atp.raw.should ==
+        s(:flow,
+          s(:name, "sort1"),
+          s(:enable, "run_flag_1"),
+          s(:if_enabled, "run_flag_1",
+            s(:test,
+              s(:object, "test_should_run"))),
+          s(:disable, "run_flag_2"),
+          s(:if_enabled, "run_flag_2",
+            s(:test,
+              s(:object, "test_should_not_run"))))
+    end
   end
 end

--- a/spec/loop_spec.rb
+++ b/spec/loop_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe 'Loop Support' do
+  include ATP::FlowAPI
+
+  before :each do
+    self.atp = ATP::Program.new.flow(:sort1) 
+  end
+
+  it "can create loop without variable specified" do
+    test :test_pre_loop
+    loop from: 0.3, to: 0.4, step: 0.1 do
+      test :test_loop1
+    end
+    test :test_post_loop
+    atp.raw.should ==
+      s(:flow,
+        s(:name, "sort1"),
+        s(:test,
+          s(:object, "test_pre_loop")),
+        s(:loop, 0.3, 0.4, 0.1,
+          s(:test,
+            s(:object, "test_loop1"))),
+        s(:test,
+          s(:object, "test_post_loop")))
+  end
+
+  it "can create loop with variable specified" do
+    test :test_pre_loop
+    loop from: 0.3, to: 0.4, step: 0.1, var: "vol" do
+      test :test_loop1
+    end
+    test :test_post_loop
+    atp.raw.should ==
+      s(:flow,
+        s(:name, "sort1"),
+        s(:test,
+          s(:object, "test_pre_loop")),
+        s(:loop, 0.3, 0.4, 0.1, "vol",
+          s(:test,
+            s(:object, "test_loop1"))),
+        s(:test,
+          s(:object, "test_post_loop")))
+  end
+end
+
+

--- a/spec/loop_spec.rb
+++ b/spec/loop_spec.rb
@@ -18,7 +18,7 @@ describe 'Loop Support' do
         s(:name, "sort1"),
         s(:test,
           s(:object, "test_pre_loop")),
-        s(:loop, 0.3, 0.4, 0.1,
+        s(:loop, 0.3, 0.4, 0.1, nil,
           s(:test,
             s(:object, "test_loop1"))),
         s(:test,

--- a/spec/var_expression_spec.rb
+++ b/spec/var_expression_spec.rb
@@ -7,70 +7,49 @@ describe 'Variable Expressions' do
     self.atp = ATP::Program.new.flow(:sort1) 
   end
 
-  it "can create if_true node" do
-    if_true eq('ONE', 1) do
-      test :test1
+  it "can create whenever node(s)" do
+    whenever eq('ONE', 1) do
+      test :test_1eq1
+    end
+    whenever le('TWO', 3) do
+      test :test_2le3
     end
 
     atp.raw.should ==
       s(:flow,
         s(:name, "sort1"),
-        s(:if_true, [s(:eq, "ONE", 1)],
+        s(:whenever, [s(:eq, "ONE", 1)],
           s(:test,
-            s(:object, "test1"))))
-
+            s(:object, "test_1eq1"))),
+        s(:whenever, [s(:le, "TWO", 3)],
+          s(:test,
+            s(:object, "test_2le3"))))
   end
 
-  it "can create if_false node" do
-    if_false eq('ONE', 2) do
-      test :test1
+  it "can create whenever_all node" do
+    whenever_all gt('FOUR', 2), ne('FIVE', 6) do
+      test :test_4gt2and5ne6
     end
 
     atp.raw.should ==
       s(:flow,
         s(:name, "sort1"),
-        s(:if_false, [s(:eq, "ONE", 2)],
+        s(:whenever_all, [s(:gt, "FOUR", 2), s(:ne, "FIVE", 6)],
           s(:test,
-            s(:object, "test1"))))
-
+            s(:object, "test_4gt2and5ne6"))))
   end
 
-  it "can translate expr into relational operator node" do
-    if_true expr(:eq, 'THREE', 3) do
-      test :test3
-    end
-    if_true expr(:lt, 'FOUR', 5) do
-      test :test4lt5
-    end
-
-
-    atp.raw.should ==
-      s(:flow,
-        s(:name, "sort1"),
-        s(:if_true, [s(:eq, "THREE", 3)],
-          s(:test,
-            s(:object, "test3"))),
-        s(:if_true, [s(:lt, "FOUR", 5)],
-          s(:test,
-            s(:object, "test4lt5"))))
-
-
-  end
-
-  it "can create if_true node with multiple relationals" do
-    if_true expr(:and, eq('ONE', 1), eq('TWO', 2)) do
-      test :test1and2
+  it "can create whenever_any node" do
+    whenever_any ge('SEVEN', 0), lt('EIGHT', 9) do
+      test :test_7ge0or8lt9
     end
 
     atp.raw.should ==
       s(:flow,
         s(:name, "sort1"),
-        s(:if_true, [s(:and,
-        s(:eq, "ONE", 1),
-        s(:eq, "TWO", 2))],
+        s(:whenever_any, [s(:ge, "SEVEN", 0), s(:lt, "EIGHT", 9)],
           s(:test,
-            s(:object, "test1and2"))))
-
+            s(:object, "test_7ge0or8lt9"))))
   end
 end
 

--- a/spec/var_expression_spec.rb
+++ b/spec/var_expression_spec.rb
@@ -51,5 +51,21 @@ describe 'Variable Expressions' do
           s(:test,
             s(:object, "test_7ge0or8lt9"))))
   end
+
+  it "can create set node" do
+    set 'ONE', 0
+
+    whenever eq('ONE', 1) do
+      test :test_1eq1
+    end
+
+    atp.raw.should ==
+      s(:flow,
+        s(:name, "sort1"),
+        s(:set, "ONE", 0),
+        s(:whenever, [s(:eq, "ONE", 1)],
+          s(:test,
+            s(:object, "test_1eq1"))))
+  end
 end
 

--- a/spec/var_expression_spec.rb
+++ b/spec/var_expression_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+describe 'Variable Expressions' do
+  include ATP::FlowAPI
+
+  before :each do
+    self.atp = ATP::Program.new.flow(:sort1) 
+  end
+
+  it "can create if_true node" do
+    if_true eq('ONE', 1) do
+      test :test1
+    end
+
+    atp.raw.should ==
+      s(:flow,
+        s(:name, "sort1"),
+        s(:if_true, [s(:eq, "ONE", 1)],
+          s(:test,
+            s(:object, "test1"))))
+
+  end
+
+  it "can create if_false node" do
+    if_false eq('ONE', 2) do
+      test :test1
+    end
+
+    atp.raw.should ==
+      s(:flow,
+        s(:name, "sort1"),
+        s(:if_false, [s(:eq, "ONE", 2)],
+          s(:test,
+            s(:object, "test1"))))
+
+  end
+
+  it "can translate expr into relational operator node" do
+    if_true expr(:eq, 'THREE', 3) do
+      test :test3
+    end
+    if_true expr(:lt, 'FOUR', 5) do
+      test :test4lt5
+    end
+
+
+    atp.raw.should ==
+      s(:flow,
+        s(:name, "sort1"),
+        s(:if_true, [s(:eq, "THREE", 3)],
+          s(:test,
+            s(:object, "test3"))),
+        s(:if_true, [s(:lt, "FOUR", 5)],
+          s(:test,
+            s(:object, "test4lt5"))))
+
+
+  end
+
+  it "can create if_true node with multiple relationals" do
+    if_true expr(:and, eq('ONE', 1), eq('TWO', 2)) do
+      test :test1and2
+    end
+
+    atp.raw.should ==
+      s(:flow,
+        s(:name, "sort1"),
+        s(:if_true, [s(:and,
+        s(:eq, "ONE", 1),
+        s(:eq, "TWO", 2))],
+          s(:test,
+            s(:object, "test1and2"))))
+
+  end
+end
+


### PR DESCRIPTION
This PR is a re-write of PR #13 based on feedback.

The new syntax is:
~~~ruby
if_true eq('ONE', 1) do
  test :test1
 end
# would render to: if "ONE" == 1

if_true lt('ONE', 2) do
  test :test1
 end
# would render to: if "ONE" < 2

if_true expr(:and, eq('ONE',1), lt('ONE', 2)) do
  test :test1
 end
# would render to: if "ONE" == 1 && "ONE" < 2
~~~

Obviously, the rendering piece will be in origen_testers (working in a local branch) so this PR is just supporting the necessary ast nodes.

